### PR TITLE
Mudando a indicação de próxima versão

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "0.2.3"
+VERSION = "0.3.0-dev"
 setup(
     name="aiologger",
     version=VERSION,


### PR DESCRIPTION
Vamos deixar na `master` sempre o número da próxima versão mais o sufixo `-dev`. Assim quem quiser fazer um `python setup.py install` vai funcionar.