### PR TITLE
add python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     name="aiologger",
     version=VERSION,
     packages=find_packages(exclude=["*test*"]),
+    python_requires=">=3.6",
     extras_require={"aiofiles": ["aiofiles==0.4.0"]},
     url="https://github.com/diogommartins/aiologger",
     author="Diogo Magalhães Martins",


### PR DESCRIPTION
Prevents package from being installed on non-supported python versions, see: #50 