### PR TITLE
fix AsyncFileHandler

### DIFF
--- a/aiologger/handlers/base.py
+++ b/aiologger/handlers/base.py
@@ -13,6 +13,10 @@ from aiologger.levels import LogLevel, get_level_name, check_level
 from aiologger.records import LogRecord
 
 
+# Handler relies on any formatter
+_default_formatter = Formatter()
+
+
 class Handler(Filterer):
     """
     Handler instances dispatch logging events to specific destinations.
@@ -35,7 +39,7 @@ class Handler(Filterer):
         """
         Filterer.__init__(self)
         self._level = check_level(level)
-        self.formatter: Optional[Formatter] = None
+        self.formatter: Formatter = _default_formatter
         self._loop: Optional[asyncio.AbstractEventLoop] = loop
 
     @property

--- a/tests/handlers/test_files.py
+++ b/tests/handlers/test_files.py
@@ -21,7 +21,6 @@ from aiologger.handlers.files import (
     ONE_MINUTE_IN_SECONDS,
     ONE_HOUR_IN_SECONDS,
 )
-from aiologger.handlers.streams import AsyncStreamHandler
 from aiologger.records import LogRecord
 from tests.utils import make_log_record
 
@@ -54,7 +53,7 @@ class AsyncFileHandlerTests(asynctest.TestCase):
             loop=loop,
         )
 
-        self.assertIsInstance(handler, AsyncStreamHandler)
+        self.assertIsInstance(handler, AsyncFileHandler)
 
         self.assertEqual(handler.absolute_file_path, self.temp_file.name)
         self.assertEqual(handler.mode, mode)
@@ -72,10 +71,12 @@ class AsyncFileHandlerTests(asynctest.TestCase):
         handler = AsyncFileHandler(filename=self.temp_file.name)
 
         await handler._init_writer()
+        self.assertFalse(handler.stream is None)
+        self.assertIsInstance(handler.stream, AsyncTextIOWrapper)
         self.assertFalse(handler.stream.closed)
 
         await handler.close()
-        self.assertTrue(handler.stream.closed)
+        self.assertTrue(handler.stream is None)
 
     async def test_emit_writes_log_records_into_the_file(self):
         handler = AsyncFileHandler(filename=self.temp_file.name)

--- a/tests/handlers/test_files.py
+++ b/tests/handlers/test_files.py
@@ -84,6 +84,8 @@ class AsyncFileHandlerTests(asynctest.TestCase):
         await handler.emit(self.record)
         await handler.emit(self.record)
 
+        await handler.flush()
+
         with open(self.temp_file.name) as fp:
             content = fp.read()
 


### PR DESCRIPTION
Seems it was broken. Removed parent AsyncStreamHandler -- flush method worked incorrectly
Fixed broken unittests associated to AsyncFileHandler
NOTE: after close handled stream sets to None. It allows to reinit AsyncFileHandler
NOTE 2: streams coverage at test_files seems wierd