### PR TITLE
Fix "Lazy initialization" example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,11 @@ import asyncio
 from aiologger import Logger
 
 
-async def main():
-    logger = Logger.with_default_handlers(name='my-logger')
+logger = Logger.with_default_handlers(name='my-logger')
 
+
+async def main():
+    
     await logger.debug("debug at stdout")
     await logger.info("info at stdout")
 


### PR DESCRIPTION
To match the surrounding explanatory text.

>Since the actual stream initialization only happens on the first log call, it's
possible to initialize `aiologger.Logger` instances outside a running event	possible to initialize `aiologger.Logger` instances outside a running event
loop: